### PR TITLE
Fix sliding sync E2EE delivery and pushes

### DIFF
--- a/src/api/keys.ts
+++ b/src/api/keys.ts
@@ -534,7 +534,11 @@ app.get('/_matrix/client/v3/keys/changes', requireAuth(), async (c) => {
         SELECT DISTINCT rm2.user_id
         FROM room_memberships rm1
         JOIN room_memberships rm2 ON rm1.room_id = rm2.room_id
-        WHERE rm1.user_id = ? AND rm1.membership = 'join' AND rm2.membership = 'join'
+        WHERE rm1.user_id = ? AND rm1.membership IN ('join', 'invite')
+          AND (
+            rm2.membership = 'join'
+            OR (rm1.membership = 'join' AND rm2.membership = 'invite')
+          )
       )
   `).bind(fromPosition, toPosition, userId).all<{
     user_id: string;

--- a/src/api/rooms.ts
+++ b/src/api/rooms.ts
@@ -349,8 +349,11 @@ app.post('/_matrix/client/v3/createRoom', requireAuth(), async (c) => {
     await createRoomAlias(c.env.DB, alias, roomId, userId);
   }
 
-  // Notify the creator's sync that the room was created
-  await notifyUsersOfEvent(c.env, roomId, roomId, 'm.room.create');
+  // Notify the creator and invitees that the room/invite state changed.
+  const inviteesToNotify = Array.isArray(invite)
+    ? invite.filter((invitee: unknown): invitee is string => typeof invitee === 'string')
+    : [];
+  await notifyUsersOfEvent(c.env, roomId, roomId, 'm.room.create', inviteesToNotify);
 
   return c.json({
     room_id: roomId,
@@ -542,8 +545,8 @@ app.post('/_matrix/client/v3/rooms/:roomId/leave', requireAuth(), async (c) => {
   await storeEvent(c.env.DB, event);
   await updateMembership(c.env.DB, roomId, userId, 'leave', eventId);
 
-  // Notify room members about the leave
-  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member');
+  // Notify room members and the leaving user's sync.
+  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member', [userId]);
 
   return c.json({});
 });
@@ -1106,8 +1109,8 @@ app.post('/_matrix/client/v3/rooms/:roomId/invite', requireAuth(), async (c) => 
   await storeEvent(c.env.DB, event);
   await updateMembership(c.env.DB, roomId, inviteeId, 'invite', eventId);
 
-  // Notify room members and the invitee about the invite
-  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member');
+  // Notify room members and the invitee about the invite.
+  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member', [inviteeId]);
 
   return c.json({});
 });
@@ -1187,8 +1190,8 @@ app.post('/_matrix/client/v3/rooms/:roomId/kick', requireAuth(), async (c) => {
   await storeEvent(c.env.DB, event);
   await updateMembership(c.env.DB, roomId, targetId, 'leave', eventId);
 
-  // Notify room members about the kick
-  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member');
+  // Notify room members and the kicked user.
+  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member', [targetId]);
 
   return c.json({});
 });
@@ -1263,8 +1266,8 @@ app.post('/_matrix/client/v3/rooms/:roomId/ban', requireAuth(), async (c) => {
   await storeEvent(c.env.DB, event);
   await updateMembership(c.env.DB, roomId, targetId, 'ban', eventId);
 
-  // Notify room members about the ban
-  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member');
+  // Notify room members and the banned user.
+  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member', [targetId]);
 
   return c.json({});
 });
@@ -1343,8 +1346,8 @@ app.post('/_matrix/client/v3/rooms/:roomId/unban', requireAuth(), async (c) => {
   await storeEvent(c.env.DB, event);
   await updateMembership(c.env.DB, roomId, targetId, 'leave', eventId);
 
-  // Notify room members about the unban
-  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member');
+  // Notify room members and the unbanned user.
+  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member', [targetId]);
 
   return c.json({});
 });
@@ -1678,6 +1681,9 @@ app.post('/_matrix/client/v3/join/:roomIdOrAlias', requireAuth(), async (c) => {
 
   await storeEvent(db, event);
   await updateMembership(db, roomId, userId, 'join', eventId);
+
+  // Keep /join/:roomIdOrAlias behavior aligned with /rooms/:roomId/join.
+  await notifyUsersOfEvent(c.env, roomId, eventId, 'm.room.member');
 
   return c.json({ room_id: roomId });
 });

--- a/src/api/sliding-sync.ts
+++ b/src/api/sliding-sync.ts
@@ -1511,6 +1511,7 @@ function detectNSERequest(
 
 // MSC4186 Simplified Sliding Sync handler (shared between endpoints)
 async function handleSimplifiedSlidingSync(c: Context<AppEnv>) {
+  const requestStartedAt = Date.now();
   const userId = c.get('userId');
   const db = c.env.DB;
   const syncDO = c.env.SYNC;  // Use Durable Object for connection state (not KV - avoids rate limits)
@@ -2203,7 +2204,7 @@ async function handleSimplifiedSlidingSync(c: Context<AppEnv>) {
       const waitResponse = await stub.fetch(new Request('http://internal/wait-for-events', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ timeout }),
+        body: JSON.stringify({ timeout, afterTimestamp: requestStartedAt }),
       }));
       const waitResult = await waitResponse.json() as { hasEvents: boolean };
 

--- a/src/api/sliding-sync.ts
+++ b/src/api/sliding-sync.ts
@@ -249,9 +249,14 @@ function getDeviceKeySyncCursor(
 
 function rememberDeviceKeySyncCursor(
   connectionState: ConnectionState,
+  requestPos: number,
   responsePos: number,
   deviceKeyPos: number,
 ): void {
+  if (responsePos <= requestPos) {
+    return;
+  }
+
   connectionState.lastDeviceKeyChangePos = Math.max(
     connectionState.lastDeviceKeyChangePos ?? 0,
     deviceKeyPos,
@@ -1292,7 +1297,7 @@ app.post('/_matrix/client/unstable/org.matrix.msc3575/sync', requireAuth(), asyn
       const lastDeviceKeyChangePos = getDeviceKeySyncCursor(connectionState, sincePos, isInitialSync);
       const { changed: deviceListChanged, left: deviceListLeft, newLastPos } =
         await buildE2EEDeviceListChanges(c.env, db, userId, lastDeviceKeyChangePos);
-      rememberDeviceKeySyncCursor(connectionState, currentStreamPos, newLastPos);
+      rememberDeviceKeySyncCursor(connectionState, sincePos, currentStreamPos, newLastPos);
 
       response.extensions.e2ee = {
         device_lists: {
@@ -1939,7 +1944,7 @@ async function handleSimplifiedSlidingSync(c: Context<AppEnv>) {
       const lastDeviceKeyChangePos = getDeviceKeySyncCursor(connectionState, sincePos, isInitialSync);
       const { changed: deviceListChanged, left: deviceListLeft, newLastPos } =
         await buildE2EEDeviceListChanges(c.env, db, userId, lastDeviceKeyChangePos);
-      rememberDeviceKeySyncCursor(connectionState, currentStreamPos, newLastPos);
+      rememberDeviceKeySyncCursor(connectionState, sincePos, currentStreamPos, newLastPos);
 
       response.extensions.e2ee = {
         device_lists: { changed: deviceListChanged, left: deviceListLeft },

--- a/src/api/sliding-sync.ts
+++ b/src/api/sliding-sync.ts
@@ -2,7 +2,7 @@
 // Implements both the original sliding sync and simplified sliding sync
 
 import { Hono, type Context } from 'hono';
-import type { AppEnv } from '../types';
+import type { AppEnv, Env } from '../types';
 import { Errors } from '../utils/errors';
 import { requireAuth } from '../middleware/auth';
 import { getTypingForRooms } from './typing';
@@ -196,8 +196,201 @@ interface ConnectionState {
   roomFullyReadMarkers?: Record<string, string>;
   // Track if initial sync has been completed to prevent ephemeral spam on reconnects
   initialSyncComplete?: boolean;
+  // Last device_key_changes stream position delivered via e2ee extension
+  lastDeviceKeyChangePos?: number;
+  // Map issued sliding-sync event pos tokens to the device_key_changes cursor used
+  // for that response. Sliding sync pos is not the same stream as device keys.
+  deviceKeyPosBySyncPos?: Record<string, number>;
   // Track rooms we've sent as "read" (notification_count = 0) to avoid resending
   roomSentAsRead?: Record<string, boolean>;
+}
+
+function getRoomSyncCursor(
+  roomState: ConnectionState['roomStates'][string] | undefined,
+  sincePos: number,
+  isInitialSync: boolean,
+): { isInitialRoom: boolean; roomSincePos: number } {
+  const isInitialRoom = isInitialSync || !roomState?.sentState;
+  if (isInitialRoom) {
+    return { isInitialRoom, roomSincePos: 0 };
+  }
+
+  // Sliding sync clients can have concurrent requests for the same conn_id.
+  // If one response advances stored room state before an older client pos is
+  // retried, using only stored state skips events. Never start after client pos.
+  const storedRoomPos = roomState.lastStreamOrdering || sincePos;
+  return { isInitialRoom, roomSincePos: Math.min(storedRoomPos, sincePos) };
+}
+
+function getDeviceKeySyncCursor(
+  connectionState: ConnectionState,
+  sincePos: number,
+  isInitialSync: boolean,
+): number {
+  if (isInitialSync) {
+    return 0;
+  }
+
+  const tokenCursor = connectionState.deviceKeyPosBySyncPos?.[String(sincePos)];
+  if (typeof tokenCursor === 'number' && Number.isFinite(tokenCursor)) {
+    return tokenCursor;
+  }
+
+  // If this request is behind the saved connection event pos, it is likely an
+  // overlapping or retried sliding-sync request. Without a pos->device cursor
+  // mapping, replay device-key changes conservatively instead of skipping them.
+  const savedEventPos = connectionState.pos ?? sincePos;
+  if (sincePos < savedEventPos) {
+    return 0;
+  }
+
+  return connectionState.lastDeviceKeyChangePos ?? 0;
+}
+
+function rememberDeviceKeySyncCursor(
+  connectionState: ConnectionState,
+  responsePos: number,
+  deviceKeyPos: number,
+): void {
+  connectionState.lastDeviceKeyChangePos = Math.max(
+    connectionState.lastDeviceKeyChangePos ?? 0,
+    deviceKeyPos,
+  );
+
+  const cursors = {
+    ...(connectionState.deviceKeyPosBySyncPos ?? {}),
+    [String(responsePos)]: deviceKeyPos,
+  };
+
+  // Keep this bounded; clients only resume from recent pos tokens.
+  const entries = Object.entries(cursors)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .slice(-32);
+  connectionState.deviceKeyPosBySyncPos = Object.fromEntries(entries);
+}
+
+async function getMaxDeviceKeyChangePosition(db: D1Database): Promise<number> {
+  const result = await db.prepare(
+    `SELECT COALESCE(MAX(stream_position), 0) as max_pos FROM device_key_changes`
+  ).first<{ max_pos: number }>();
+  return result?.max_pos ?? 0;
+}
+
+async function userHasDeviceKeys(env: Env, targetUserId: string): Promise<boolean> {
+  try {
+    const userKeysDO = env.USER_KEYS.get(env.USER_KEYS.idFromName(targetUserId));
+    const deviceIdsResp = await userKeysDO.fetch(new Request('http://internal/device-keys/list'));
+    if (!deviceIdsResp.ok) {
+      return false;
+    }
+    const deviceIds = await deviceIdsResp.json() as string[];
+    if (deviceIds.length > 0) {
+      return true;
+    }
+
+    const crossSigningResp = await userKeysDO.fetch(new Request('http://internal/cross-signing/get'));
+    if (!crossSigningResp.ok) {
+      return false;
+    }
+    const crossSigningKeys = await crossSigningResp.json() as Record<string, unknown>;
+    return Object.keys(crossSigningKeys).length > 0;
+  } catch (error) {
+    console.error('[sliding-sync] userHasDeviceKeys failed for', targetUserId, error);
+    return false;
+  }
+}
+
+async function getSharedRoomMemberIds(db: D1Database, userId: string): Promise<string[]> {
+  const members = await db.prepare(`
+    SELECT DISTINCT rm2.user_id
+    FROM room_memberships rm1
+    JOIN room_memberships rm2 ON rm1.room_id = rm2.room_id
+    WHERE rm1.user_id = ? AND rm1.membership IN ('join', 'invite')
+      AND (
+        rm2.membership = 'join'
+        OR (rm1.membership = 'join' AND rm2.membership = 'invite')
+      )
+  `).bind(userId).all<{ user_id: string }>();
+  return members.results.map(row => row.user_id);
+}
+
+async function getUsersWithKeyChangesInSharedRooms(
+  db: D1Database,
+  userId: string,
+  sincePos: number,
+): Promise<{ changed: string[]; left: string[] }> {
+  const changes = await db.prepare(`
+    SELECT DISTINCT dkc.user_id, dkc.change_type
+    FROM device_key_changes dkc
+    WHERE dkc.stream_position > ?
+      AND (
+        dkc.user_id = ?
+        OR EXISTS (
+          SELECT 1 FROM room_memberships rm1
+          JOIN room_memberships rm2 ON rm1.room_id = rm2.room_id
+          WHERE rm1.user_id = ? AND rm1.membership IN ('join', 'invite')
+            AND rm2.user_id = dkc.user_id
+            AND (
+              rm2.membership = 'join'
+              OR (rm1.membership = 'join' AND rm2.membership = 'invite')
+            )
+        )
+      )
+  `).bind(sincePos, userId, userId).all<{ user_id: string; change_type: string }>();
+
+  const changed: string[] = [];
+  const left: string[] = [];
+  for (const change of changes.results) {
+    if (change.change_type === 'delete') {
+      if (!left.includes(change.user_id)) {
+        left.push(change.user_id);
+      }
+    } else if (!changed.includes(change.user_id)) {
+      changed.push(change.user_id);
+    }
+  }
+  return { changed, left };
+}
+
+async function buildE2EEDeviceListChanges(
+  env: Env,
+  db: D1Database,
+  userId: string,
+  lastDeviceKeyChangePos: number,
+): Promise<{ changed: string[]; left: string[]; newLastPos: number }> {
+  const newLastPos = await getMaxDeviceKeyChangePosition(db);
+  const changed: string[] = [];
+  const left: string[] = [];
+
+  // Use device_key_changes stream (not event pos). On first connect, sincePos=0
+  // returns everyone in shared rooms who has ever uploaded keys — one SQL query,
+  // not N Durable Object round-trips (which caused sync timeouts / "server unavailable").
+  const { changed: fromChanges, left: fromLeft } = await getUsersWithKeyChangesInSharedRooms(
+    db,
+    userId,
+    lastDeviceKeyChangePos,
+  );
+  changed.push(...fromChanges);
+  left.push(...fromLeft);
+
+  if (lastDeviceKeyChangePos === 0) {
+    // Ensure self appears if keys exist but no change row yet (edge case)
+    if (!changed.includes(userId) && await userHasDeviceKeys(env, userId)) {
+      changed.push(userId);
+    }
+    // Room members with keys but no device_key_changes row yet (rare)
+    const members = await getSharedRoomMemberIds(db, userId);
+    const missing = members.filter(m => m !== userId && !changed.includes(m));
+    if (missing.length > 0 && missing.length <= 10) {
+      for (const memberId of missing) {
+        if (await userHasDeviceKeys(env, memberId)) {
+          changed.push(memberId);
+        }
+      }
+    }
+  }
+
+  return { changed, left, newLastPos };
 }
 
 // Helper to get the current maximum stream ordering from the database
@@ -764,8 +957,7 @@ app.post('/_matrix/client/unstable/org.matrix.msc3575/sync', requireAuth(), asyn
   const queryPos = c.req.query('pos');
   const posToken = queryPos || body.pos;
   const sincePos = posToken ? parseInt(posToken) : 0;
-  // Note: isInitialSync is computed but not currently used (for future diagnostics)
-  void (!posToken || !connectionState);
+  const isInitialSync = !posToken || sincePos === 0;
 
   // If client sends a pos but we don't have connection state, check if the pos
   // is a valid stream position (could be from before a deployment or KV expiry)
@@ -862,8 +1054,7 @@ app.post('/_matrix/client/unstable/org.matrix.msc3575/sync', requireAuth(), asyn
       // Get room data for rooms in range
       for (const roomInfo of roomsInRange) {
         const roomState = connectionState.roomStates[roomInfo.roomId];
-        const isInitialRoom = !roomState?.sentState;
-        const roomSincePos = isInitialRoom ? 0 : (roomState?.lastStreamOrdering || 0);
+        const { isInitialRoom, roomSincePos } = getRoomSyncCursor(roomState, sincePos, isInitialSync);
 
         // Handle invited rooms differently - they get invite_state not timeline
         // Always include invited room data (small payload) so client doesn't lose invites on reconnect
@@ -959,8 +1150,7 @@ app.post('/_matrix/client/unstable/org.matrix.msc3575/sync', requireAuth(), asyn
       }
 
       const roomState = connectionState.roomStates[roomId];
-      const isInitialRoom = !roomState?.sentState;
-      const roomSincePos = isInitialRoom ? 0 : (roomState?.lastStreamOrdering || 0);
+      const { isInitialRoom, roomSincePos } = getRoomSyncCursor(roomState, sincePos, isInitialSync);
 
       // Handle invited rooms differently - they get invite_state not timeline
       // Always include invited room data (small payload) so client doesn't lose invites on reconnect
@@ -1098,49 +1288,16 @@ app.post('/_matrix/client/unstable/org.matrix.msc3575/sync', requireAuth(), asyn
         unusedFallbackTypes.push(...(fallbackKeys.results as { algorithm: string }[]).map(row => row.algorithm));
       }
 
-      // Get device list changes
-      // Include the current user's own changes (important for cross-signing verification)
-      // AND other users who share rooms with the current user
-      const sincePos = body.pos ? parseInt(body.pos) : 0;
-      const deviceListChanged: string[] = [];
-
-      if (sincePos === 0) {
-        // CRITICAL FIX: On first sync, include user's own ID if they have device keys
-        // This is essential for E2EE bootstrap - Element X needs to see its own user
-        // in device_lists.changed to know cross-signing keys were uploaded successfully
-        const userKeysDO = c.env.USER_KEYS.get(c.env.USER_KEYS.idFromName(userId));
-        const deviceIdsResp = await userKeysDO.fetch(new Request('http://internal/device-keys/list'));
-        const deviceIds = await deviceIdsResp.json() as string[];
-
-        // Also check for cross-signing keys
-        const crossSigningResp = await userKeysDO.fetch(new Request('http://internal/cross-signing/get'));
-        const crossSigningKeys = await crossSigningResp.json() as Record<string, any>;
-
-        if (deviceIds.length > 0 || Object.keys(crossSigningKeys).length > 0) {
-          deviceListChanged.push(userId);
-        }
-      } else {
-        const changes = await db.prepare(`
-          SELECT DISTINCT dkc.user_id
-          FROM device_key_changes dkc
-          WHERE dkc.stream_position > ?
-            AND (
-              dkc.user_id = ?
-              OR EXISTS (
-                SELECT 1 FROM room_memberships rm1
-                JOIN room_memberships rm2 ON rm1.room_id = rm2.room_id
-                WHERE rm1.user_id = ? AND rm1.membership = 'join'
-                  AND rm2.user_id = dkc.user_id AND rm2.membership = 'join'
-              )
-            )
-        `).bind(sincePos, userId, userId).all();
-        deviceListChanged.push(...(changes.results as { user_id: string }[]).map(row => row.user_id));
-      }
+      // Get device list changes (use device_key_changes stream, NOT event stream pos)
+      const lastDeviceKeyChangePos = getDeviceKeySyncCursor(connectionState, sincePos, isInitialSync);
+      const { changed: deviceListChanged, left: deviceListLeft, newLastPos } =
+        await buildE2EEDeviceListChanges(c.env, db, userId, lastDeviceKeyChangePos);
+      rememberDeviceKeySyncCursor(connectionState, currentStreamPos, newLastPos);
 
       response.extensions.e2ee = {
         device_lists: {
           changed: deviceListChanged,
-          left: [],
+          left: deviceListLeft,
         },
         device_one_time_keys_count: keyCounts,
         device_unused_fallback_key_types: unusedFallbackTypes,
@@ -1530,8 +1687,7 @@ async function handleSimplifiedSlidingSync(c: Context<AppEnv>) {
 
       for (const roomInfo of roomsInRange) {
         const roomState = connectionState.roomStates[roomInfo.roomId];
-        const isInitialRoom = !roomState?.sentState;
-        const roomSincePos = isInitialRoom ? 0 : (roomState?.lastStreamOrdering || sincePos);
+        const { isInitialRoom, roomSincePos } = getRoomSyncCursor(roomState, sincePos, isInitialSync);
 
         // Handle invited rooms differently - they get invite_state not timeline
         // Always include invited room data (small payload) so client doesn't lose invites on reconnect
@@ -1629,8 +1785,7 @@ async function handleSimplifiedSlidingSync(c: Context<AppEnv>) {
       if (!membershipResult) continue;
 
       const roomState = connectionState.roomStates[roomId];
-      const isInitialRoom = !roomState?.sentState;
-      const roomSincePos = isInitialRoom ? 0 : (roomState?.lastStreamOrdering || sincePos);
+      const { isInitialRoom, roomSincePos } = getRoomSyncCursor(roomState, sincePos, isInitialSync);
 
       // Handle invited rooms differently - they get invite_state not timeline
       // Always include invited room data (small payload) so client doesn't lose invites on reconnect
@@ -1745,6 +1900,9 @@ async function handleSimplifiedSlidingSync(c: Context<AppEnv>) {
         next_batch: nextBatch,
         events,
       };
+      if (events.length > 0) {
+        hasChanges = true;
+      }
     }
 
     // e2ee: enabled if key exists (MSC4186) or enabled=true (MSC3575)
@@ -1776,50 +1934,20 @@ async function handleSimplifiedSlidingSync(c: Context<AppEnv>) {
         unusedFallbackTypes.push(...(fallbackKeys.results as { algorithm: string }[]).map(row => row.algorithm));
       }
 
-      // Get device list changes
-      // Include the current user's own changes (important for cross-signing verification)
-      // AND other users who share rooms with the current user
-      const sincePos = body.pos ? parseInt(body.pos) : 0;
-      const deviceListChanged: string[] = [];
-
-      if (sincePos === 0) {
-        // CRITICAL FIX: On first sync, include user's own ID if they have device keys
-        // This is essential for E2EE bootstrap - Element X needs to see its own user
-        // in device_lists.changed to know cross-signing keys were uploaded successfully
-        const userKeysDO = c.env.USER_KEYS.get(c.env.USER_KEYS.idFromName(userId));
-        const deviceIdsResp = await userKeysDO.fetch(new Request('http://internal/device-keys/list'));
-        const deviceIds = await deviceIdsResp.json() as string[];
-
-        // Also check for cross-signing keys
-        const crossSigningResp = await userKeysDO.fetch(new Request('http://internal/cross-signing/get'));
-        const crossSigningKeys = await crossSigningResp.json() as Record<string, any>;
-
-        if (deviceIds.length > 0 || Object.keys(crossSigningKeys).length > 0) {
-          deviceListChanged.push(userId);
-        }
-      } else {
-        const changes = await db.prepare(`
-          SELECT DISTINCT dkc.user_id
-          FROM device_key_changes dkc
-          WHERE dkc.stream_position > ?
-            AND (
-              dkc.user_id = ?
-              OR EXISTS (
-                SELECT 1 FROM room_memberships rm1
-                JOIN room_memberships rm2 ON rm1.room_id = rm2.room_id
-                WHERE rm1.user_id = ? AND rm1.membership = 'join'
-                  AND rm2.user_id = dkc.user_id AND rm2.membership = 'join'
-              )
-            )
-        `).bind(sincePos, userId, userId).all();
-        deviceListChanged.push(...(changes.results as { user_id: string }[]).map(row => row.user_id));
-      }
+      // Get device list changes (use device_key_changes stream, NOT event stream pos)
+      const lastDeviceKeyChangePos = getDeviceKeySyncCursor(connectionState, sincePos, isInitialSync);
+      const { changed: deviceListChanged, left: deviceListLeft, newLastPos } =
+        await buildE2EEDeviceListChanges(c.env, db, userId, lastDeviceKeyChangePos);
+      rememberDeviceKeySyncCursor(connectionState, currentStreamPos, newLastPos);
 
       response.extensions.e2ee = {
-        device_lists: { changed: deviceListChanged, left: [] },
+        device_lists: { changed: deviceListChanged, left: deviceListLeft },
         device_one_time_keys_count: keyCounts,
         device_unused_fallback_key_types: unusedFallbackTypes,
       };
+      if (deviceListChanged.length > 0 || deviceListLeft.length > 0) {
+        hasChanges = true;
+      }
     }
 
     // account_data: enabled if key exists (MSC4186) or enabled=true (MSC3575)

--- a/src/api/sync.ts
+++ b/src/api/sync.ts
@@ -250,6 +250,7 @@ function buildSyncToken(eventsPos: number, toDevicePos: number): string {
 }
 
 app.get('/_matrix/client/v3/sync', requireAuth(), async (c) => {
+  const requestStartedAt = Date.now();
   const userId = c.get('userId');
   const deviceId = c.get('deviceId');
 
@@ -564,7 +565,7 @@ app.get('/_matrix/client/v3/sync', requireAuth(), async (c) => {
     const waitResponse = await stub.fetch(new Request('http://internal/wait-for-events', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ timeout: waitTimeout }),
+      body: JSON.stringify({ timeout: waitTimeout, afterTimestamp: requestStartedAt }),
     }));
 
     const waitResult = await waitResponse.json() as { hasEvents: boolean };

--- a/src/api/to-device.ts
+++ b/src/api/to-device.ts
@@ -309,23 +309,17 @@ export async function getToDeviceMessages(
     content: JSON.parse(msg.content),
   }));
 
-  // Get the current max stream position for to-device messages
-  // This ensures we always return a valid next_batch, even on first sync
-  const currentPos = await db.prepare(`
-    SELECT COALESCE(MAX(stream_position), 0) as max_pos FROM to_device_messages
-  `).first<{ max_pos: number }>();
-  const maxStreamPos = currentPos?.max_pos || 0;
-
   // Return the appropriate next_batch:
   // - If we returned messages: use the max position of those messages
-  // - Otherwise: use the current max stream position (client is caught up)
+  // - Otherwise: keep the device cursor unchanged. Advancing to the global
+  //   to-device max can skip messages that belong to other devices now and
+  //   messages for this device that race in after the empty query.
   let nextBatch: string;
   if (messages.results.length > 0) {
     const maxReturnedPos = Math.max(...messages.results.map(m => m.stream_position));
     nextBatch = String(maxReturnedPos);
   } else {
-    // No messages to return - use current max position so client knows where we are
-    nextBatch = String(maxStreamPos);
+    nextBatch = String(sincePos);
   }
 
   return { events, nextBatch };

--- a/src/api/to-device.ts
+++ b/src/api/to-device.ts
@@ -9,7 +9,7 @@
 // Messages are delivered via /sync and sliding sync extensions
 
 import { Hono } from 'hono';
-import type { AppEnv } from '../types';
+import type { AppEnv, Env } from '../types';
 import { Errors } from '../utils/errors';
 import { requireAuth } from '../middleware/auth';
 
@@ -61,6 +61,79 @@ async function getUserDevices(db: D1Database, userId: string): Promise<string[]>
   return devices.results.map(d => d.device_id);
 }
 
+function makeToDeviceMessageId(
+  senderUserId: string,
+  txnId: string,
+  recipientUserId: string,
+  targetDeviceId: string,
+  eventType: string
+): string {
+  // One Matrix to-device transaction contains at most one message per
+  // recipient device for a given event type. Deterministic IDs make retries
+  // idempotent even if notification wakeup failed before the txn was stored.
+  return `to_device:${senderUserId}:${txnId}:${recipientUserId}:${targetDeviceId}:${eventType}`;
+}
+
+function escapeSqlLike(value: string): string {
+  return value.replace(/[!%_]/g, char => `!${char}`);
+}
+
+async function getPendingRecipientsForTransaction(
+  db: D1Database,
+  senderUserId: string,
+  txnId: string
+): Promise<string[]> {
+  const messagePrefix = escapeSqlLike(`to_device:${senderUserId}:${txnId}:`) + '%';
+  const rows = await db.prepare(`
+    SELECT DISTINCT recipient_user_id
+    FROM to_device_messages
+    WHERE sender_user_id = ?
+      AND delivered = 0
+      AND message_id LIKE ? ESCAPE '!'
+  `).bind(senderUserId, messagePrefix).all<{ recipient_user_id: string }>();
+
+  return rows.results.map(row => row.recipient_user_id);
+}
+
+async function notifyToDeviceRecipients(
+  env: Env,
+  recipientUserIds: Iterable<string>,
+  senderUserId: string,
+  eventType: string,
+  txnId: string
+): Promise<boolean> {
+  const uniqueRecipients = [...new Set(recipientUserIds)].filter(Boolean);
+  if (uniqueRecipients.length === 0) {
+    return true;
+  }
+
+  const results = await Promise.all(uniqueRecipients.map(async (recipientUserId) => {
+    try {
+      const timestamp = Date.now();
+      const syncDO = env.SYNC.get(env.SYNC.idFromName(recipientUserId));
+      const response = await syncDO.fetch(new Request('http://internal/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          event_id: `to_device:${senderUserId}:${eventType}:${txnId}:${recipientUserId}:${crypto.randomUUID()}`,
+          room_id: '',
+          type: eventType,
+          timestamp,
+        }),
+      }));
+      if (!response.ok) {
+        throw new Error(`Sync notify failed with status ${response.status}`);
+      }
+      return true;
+    } catch (error) {
+      console.error('[to-device] Failed to notify recipient sync:', recipientUserId, error);
+      return false;
+    }
+  }));
+
+  return results.every(Boolean);
+}
+
 // ============================================
 // Endpoints
 // ============================================
@@ -78,6 +151,9 @@ app.put('/_matrix/client/v3/sendToDevice/:eventType/:txnId', requireAuth(), asyn
   `).bind(userId, txnId).first<{ response: string }>();
 
   if (existingTxn) {
+    const pendingRecipients = await getPendingRecipientsForTransaction(db, userId, txnId);
+    await notifyToDeviceRecipients(c.env, pendingRecipients, userId, eventType, txnId);
+
     // Return cached response for idempotency
     return c.json(JSON.parse(existingTxn.response || '{}'));
   }
@@ -92,6 +168,8 @@ app.put('/_matrix/client/v3/sendToDevice/:eventType/:txnId', requireAuth(), asyn
   if (!body.messages) {
     return Errors.missingParam('messages').toResponse();
   }
+
+  const recipientsToNotify = new Set<string>();
 
   // Process each recipient user
   for (const [recipientUserId, deviceMessages] of Object.entries(body.messages)) {
@@ -109,7 +187,7 @@ app.put('/_matrix/client/v3/sendToDevice/:eventType/:txnId', requireAuth(), asyn
       // Create a message for each target device
       for (const targetDeviceId of targetDevices) {
         const streamPosition = await getNextStreamPosition(db, 'to_device');
-        const messageId = `${userId}_${txnId}_${recipientUserId}_${targetDeviceId}_${Date.now()}`;
+        const messageId = makeToDeviceMessageId(userId, txnId, recipientUserId, targetDeviceId, eventType);
 
         await db.prepare(`
           INSERT INTO to_device_messages (
@@ -126,16 +204,28 @@ app.put('/_matrix/client/v3/sendToDevice/:eventType/:txnId', requireAuth(), asyn
           messageId,
           streamPosition
         ).run();
+        recipientsToNotify.add(recipientUserId);
       }
     }
   }
 
-  // Store transaction for idempotency
-  await db.prepare(`
-    INSERT INTO transaction_ids (user_id, txn_id, response)
-    VALUES (?, ?, '{}')
-    ON CONFLICT (user_id, txn_id) DO NOTHING
-  `).bind(userId, txnId).run();
+  const notified = await notifyToDeviceRecipients(c.env, recipientsToNotify, userId, eventType, txnId);
+  if (notified) {
+    // Store transaction for idempotency only after wakeups were accepted. If a
+    // wakeup failed, a client retry will hit deterministic message IDs and try
+    // the notify path again without duplicating stored messages.
+    await db.prepare(`
+      INSERT INTO transaction_ids (user_id, txn_id, response)
+      VALUES (?, ?, '{}')
+      ON CONFLICT (user_id, txn_id) DO NOTHING
+    `).bind(userId, txnId).run();
+  } else {
+    console.warn('[to-device] Not storing transaction id after failed sync wakeup', {
+      userId,
+      txnId,
+      eventType,
+    });
+  }
 
   return c.json({});
 });

--- a/src/durable-objects/SyncDurableObject.ts
+++ b/src/durable-objects/SyncDurableObject.ts
@@ -32,6 +32,8 @@ interface SlidingSyncConnectionState {
   roomNotificationCounts?: Record<string, number>;
   roomFullyReadMarkers?: Record<string, string>;
   initialSyncComplete?: boolean;
+  lastDeviceKeyChangePos?: number;
+  deviceKeyPosBySyncPos?: Record<string, number>;
   roomSentAsRead?: Record<string, boolean>;
 }
 

--- a/src/durable-objects/SyncDurableObject.ts
+++ b/src/durable-objects/SyncDurableObject.ts
@@ -235,8 +235,19 @@ export class SyncDurableObject extends DurableObject<Env> {
   // Wait for events (used by long-polling sliding sync)
   private async handleWaitForEvents(request: Request): Promise<Response> {
     try {
-      const body = await request.json() as { timeout?: number };
-      const timeout = Math.min(body.timeout || 25000, 25000); // Cap at 25s
+      const body = await request.json() as { timeout?: number; afterTimestamp?: number };
+      const requestedTimeout = Number.isFinite(body.timeout) ? body.timeout! : 25000;
+      const timeout = Math.min(Math.max(requestedTimeout, 0), 25000); // Cap at 25s
+      const afterTimestamp = Number.isFinite(body.afterTimestamp) ? body.afterTimestamp : undefined;
+
+      this.pendingEvents = this.pendingEvents.filter(event => event.timestamp >= Date.now() - 60000);
+
+      if (afterTimestamp !== undefined && this.pendingEvents.some(event => event.timestamp >= afterTimestamp)) {
+        console.log('[SyncDO] /wait-for-events found pending event after timestamp:', afterTimestamp);
+        return new Response(JSON.stringify({ hasEvents: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
 
       console.log('[SyncDO] /wait-for-events started, timeout:', timeout, 'current waiters:', this.waitingResolvers.length);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,7 +328,7 @@ app.post('/_matrix/client/v3/user_directory/search', requireAuth(), async (c) =>
     return c.json({ errcode: 'M_BAD_JSON', error: 'Invalid JSON' }, 400);
   }
 
-  const searchTerm = body.search_term || '';
+  const searchTerm = (body.search_term || '').trim();
   const limit = Math.min(body.limit || 10, 50);
 
   console.log('[user_directory] Search request:', {
@@ -342,27 +342,114 @@ app.post('/_matrix/client/v3/user_directory/search', requireAuth(), async (c) =>
     return c.json({ results: [], limited: false });
   }
 
-  // Search for users using FTS5 for ranked full-text search
-  const ftsSearchTerm = searchTerm.replace(/['"*()]/g, ' ').trim();
-  const results = await db.prepare(`
-    SELECT u.user_id, u.display_name, u.avatar_url
-    FROM users_fts fts
-    JOIN users u ON fts.user_id = u.user_id
-    WHERE users_fts MATCH ?
-      AND u.is_deactivated = 0
-      AND u.is_guest = 0
-      AND u.user_id != ?
-    ORDER BY bm25(users_fts)
-    LIMIT ?
-  `).bind(ftsSearchTerm, requestingUserId, limit + 1).all<{
+  type DirectoryUser = {
     user_id: string;
     display_name: string | null;
     avatar_url: string | null;
-  }>();
+  };
 
-  const limited = results.results.length > limit;
+  const usersById = new Map<string, DirectoryUser>();
+  const addUsers = (rows: DirectoryUser[]) => {
+    for (const user of rows) {
+      if (user.user_id !== requestingUserId && !usersById.has(user.user_id)) {
+        usersById.set(user.user_id, user);
+      }
+    }
+  };
+
+  const localServerSuffix = `:${c.env.SERVER_NAME}`.toLowerCase();
+  const normalizedTerm = searchTerm.toLowerCase();
+  const localpartTerm = normalizedTerm.startsWith('@')
+    ? normalizedTerm.slice(1).split(':')[0]
+    : normalizedTerm.split(':')[0];
+
+  // Exact Matrix ID / short localpart lookup first. Element X uses this to
+  // decide whether "Send invite" is safe, so it must not depend on FTS.
+  const exactResults = await db.prepare(`
+    SELECT user_id, display_name, avatar_url
+    FROM users
+    WHERE is_deactivated = 0
+      AND is_guest = 0
+      AND user_id != ?
+      AND (
+        LOWER(user_id) = ?
+        OR LOWER(localpart) = ?
+        OR LOWER(user_id) = ?
+      )
+    LIMIT ?
+  `).bind(
+    requestingUserId,
+    normalizedTerm,
+    localpartTerm,
+    normalizedTerm.includes(':') ? normalizedTerm : `@${localpartTerm}${localServerSuffix}`,
+    limit + 1,
+  ).all<DirectoryUser>();
+  addUsers(exactResults.results);
+
+  // FTS is optional: older databases may not have users_fts, and Matrix IDs
+  // contain punctuation that can produce poor MATCH queries. Fall back below.
+  const ftsSearchTerm = searchTerm
+    .replace(/[@:.'"*()]/g, ' ')
+    .replace(/[^A-Za-z0-9_]+/g, ' ')
+    .trim();
+  if (ftsSearchTerm && usersById.size === 0) {
+    try {
+      const results = await db.prepare(`
+        SELECT u.user_id, u.display_name, u.avatar_url
+        FROM users_fts fts
+        JOIN users u ON fts.user_id = u.user_id
+        WHERE users_fts MATCH ?
+          AND u.is_deactivated = 0
+          AND u.is_guest = 0
+          AND u.user_id != ?
+        ORDER BY bm25(users_fts)
+        LIMIT ?
+      `).bind(ftsSearchTerm, requestingUserId, limit + 1).all<DirectoryUser>();
+      addUsers(results.results);
+    } catch (error) {
+      console.warn('[user_directory] FTS unavailable, using SQL fallback:', error);
+    }
+  }
+
+  if (usersById.size <= limit) {
+    const likeTerm = `%${normalizedTerm.replace(/^@/, '')}%`;
+    const fallbackResults = await db.prepare(`
+      SELECT user_id, display_name, avatar_url
+      FROM users
+      WHERE is_deactivated = 0
+        AND is_guest = 0
+        AND user_id != ?
+        AND (
+          LOWER(user_id) LIKE ?
+          OR LOWER(localpart) LIKE ?
+          OR LOWER(COALESCE(display_name, '')) LIKE ?
+        )
+      ORDER BY
+        CASE
+          WHEN LOWER(localpart) = ? THEN 0
+          WHEN LOWER(user_id) = ? THEN 1
+          WHEN LOWER(localpart) LIKE ? THEN 2
+          ELSE 3
+        END,
+        user_id
+      LIMIT ?
+    `).bind(
+      requestingUserId,
+      likeTerm,
+      likeTerm,
+      likeTerm,
+      localpartTerm,
+      normalizedTerm,
+      `${localpartTerm}%`,
+      limit + 1,
+    ).all<DirectoryUser>();
+    addUsers(fallbackResults.results);
+  }
+
+  const allUsers = [...usersById.values()];
+  const limited = allUsers.length > limit;
   // Return explicit null values (not undefined/omitted) so Element X knows user exists
-  const users = results.results.slice(0, limit).map(u => ({
+  const users = allUsers.slice(0, limit).map(u => ({
     user_id: u.user_id,
     display_name: u.display_name || null,
     avatar_url: u.avatar_url || null,

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -749,21 +749,27 @@ export async function notifyUsersOfEvent(
   env: Env,
   roomId: string,
   eventId: string,
-  eventType: string
+  eventType: string,
+  extraUserIds: string[] = []
 ): Promise<void> {
   try {
-    // Get all joined members of the room
+    // Get joined members of the room and add explicit targets for membership
+    // changes where the target is not joined yet/anymore (invite, leave, ban).
     const members = await env.DB.prepare(
       `SELECT user_id FROM room_memberships WHERE room_id = ? AND membership = 'join'`
     ).bind(roomId).all<{ user_id: string }>();
+    const userIds = [...new Set([
+      ...members.results.map(member => member.user_id),
+      ...extraUserIds.filter(Boolean),
+    ])];
 
-    console.log('[database] Notifying', members.results.length, 'users of event', eventId,
-      'users:', members.results.map(m => m.user_id).join(', '));
+    console.log('[database] Notifying', userIds.length, 'users of event', eventId,
+      'users:', userIds.join(', '));
 
     // Notify each user's SyncDurableObject in parallel
-    const notifications = members.results.map(async (member) => {
+    const notifications = userIds.map(async (userId) => {
       try {
-        const syncDO = env.SYNC.get(env.SYNC.idFromName(member.user_id));
+        const syncDO = env.SYNC.get(env.SYNC.idFromName(userId));
         await syncDO.fetch(new Request('http://internal/notify', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -776,7 +782,7 @@ export async function notifyUsersOfEvent(
         }));
       } catch (error) {
         // Don't fail the whole operation if one notification fails
-        console.error(`[database] Failed to notify user ${member.user_id} of event:`, error);
+        console.error(`[database] Failed to notify user ${userId} of event:`, error);
       }
     });
 

--- a/src/workflows/PushNotificationWorkflow.ts
+++ b/src/workflows/PushNotificationWorkflow.ts
@@ -259,7 +259,7 @@ export class PushNotificationWorkflow extends WorkflowEntrypoint<Env, PushParams
         }
 
         // Queue notification for history
-        await this.queueNotification(userId, eventContext, pushResult);
+        await this.queueNotification(userId, eventContext, pushResult, anySuccess);
 
         return { userId, notified: anySuccess, skipped: false };
       } catch (error) {
@@ -315,9 +315,13 @@ export class PushNotificationWorkflow extends WorkflowEntrypoint<Env, PushParams
       SELECT COUNT(*) as count FROM events e
       WHERE e.room_id = ?
         AND e.stream_ordering > COALESCE(
-          (SELECT CAST(json_extract(content, '$.event_id') AS TEXT) FROM account_data
-           WHERE user_id = ? AND room_id = ? AND event_type = 'm.fully_read'),
-          ''
+          (
+            SELECT fe.stream_ordering
+            FROM account_data ad
+            JOIN events fe ON fe.event_id = json_extract(ad.content, '$.event_id')
+            WHERE ad.user_id = ? AND ad.room_id = ? AND ad.event_type = 'm.fully_read'
+          ),
+          0
         )
         AND e.sender != ?
         AND e.event_type IN ('m.room.message', 'm.room.encrypted')
@@ -329,7 +333,7 @@ export class PushNotificationWorkflow extends WorkflowEntrypoint<Env, PushParams
   // Get user's pushers
   private async getUserPushers(userId: string): Promise<SerializablePusher[]> {
     const result = await this.env.DB.prepare(`
-      SELECT pushkey, kind, app_id, data FROM pushers WHERE user_id = ?
+      SELECT pushkey, kind, app_id, data FROM pushers WHERE user_id = ? AND enabled = 1
     `).bind(userId).all<{ pushkey: string; kind: string; app_id: string; data: string }>();
 
     return result.results.map(p => ({
@@ -429,13 +433,44 @@ export class PushNotificationWorkflow extends WorkflowEntrypoint<Env, PushParams
       });
 
       if (response.ok) {
+        let gatewayResponse: any = {};
+        try {
+          gatewayResponse = await response.json();
+        } catch {
+          gatewayResponse = {};
+        }
+
+        const rejected = Array.isArray(gatewayResponse.rejected) ? gatewayResponse.rejected : [];
+        if (rejected.includes(pusher.pushkey)) {
+          console.warn('[PushNotificationWorkflow] Gateway rejected pusher', {
+            userId,
+            appId: pusher.appId,
+          });
+          await this.env.DB.prepare(`
+            UPDATE pushers SET last_failure = ?, failure_count = failure_count + 1
+            WHERE user_id = ? AND pushkey = ? AND app_id = ?
+          `).bind(Date.now(), userId, pusher.pushkey, pusher.appId).run();
+          return false;
+        }
+
         // Update pusher success
         await this.env.DB.prepare(`
           UPDATE pushers SET last_success = ?, failure_count = 0
           WHERE user_id = ? AND pushkey = ? AND app_id = ?
         `).bind(Date.now(), userId, pusher.pushkey, pusher.appId).run();
+        console.log('[PushNotificationWorkflow] Gateway accepted push', {
+          userId,
+          appId: pusher.appId,
+        });
         return true;
       } else {
+        const errorText = await response.text().catch(() => '');
+        console.error('[PushNotificationWorkflow] Gateway failed', {
+          userId,
+          appId: pusher.appId,
+          status: response.status,
+          error: errorText,
+        });
         // Update pusher failure
         await this.env.DB.prepare(`
           UPDATE pushers SET last_failure = ?, failure_count = failure_count + 1
@@ -457,17 +492,19 @@ export class PushNotificationWorkflow extends WorkflowEntrypoint<Env, PushParams
   private async queueNotification(
     userId: string,
     eventContext: { eventId: string; roomId: string },
-    pushResult: PushRuleResult
+    pushResult: PushRuleResult,
+    pushed: boolean,
   ): Promise<void> {
     await this.env.DB.prepare(`
-      INSERT INTO notification_queue (user_id, room_id, event_id, notification_type, actions)
-      VALUES (?, ?, ?, ?, ?)
+      INSERT INTO notification_queue (user_id, room_id, event_id, notification_type, actions, pushed)
+      VALUES (?, ?, ?, ?, ?, ?)
     `).bind(
       userId,
       eventContext.roomId,
       eventContext.eventId,
       pushResult.highlight ? 'highlight' : 'notify',
-      JSON.stringify(pushResult.actions)
+      JSON.stringify(pushResult.actions),
+      pushed ? 1 : 0,
     ).run();
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes several Matrix client interoperability issues around sliding sync, E2EE key delivery, room membership notifications, to-device wakeups, user directory lookup, and push delivery.

The changes are intentionally scoped to generic server behavior. They do not include deployment-specific Cloudflare configuration, account IDs, CI changes, local test users, or private environment settings.

## What changed

### Sliding sync and E2EE device list handling

- Track `lastDeviceKeyChangePos` separately from the event stream position.
- Keep a bounded `deviceKeyPosBySyncPos` map so issued sliding-sync event `pos` tokens can resume from the matching `device_key_changes` cursor.
- Conservatively replay device-key changes when an overlapping/retried request is behind the saved connection event position and no matching device cursor is available.
- Build `device_lists.changed` from the `device_key_changes` stream rather than comparing device key rows to `events.stream_ordering`.
- Include users in shared joined rooms, and invite targets visible from a joined user's room, when reporting key changes.
- Keep the initial E2EE bootstrap path, including the current user's own device/cross-signing keys.
- Use one SQL query for shared-room key changes instead of repeatedly calling the user-keys Durable Object for each member.

This fixes a real mismatch between Matrix event stream positions and device-key stream positions. When a client resumed sliding sync with an event stream `pos`, the previous code could query `device_key_changes.stream_position > pos`; if event positions were much larger than device-key positions, the query always returned an empty device list. E2EE clients then missed another user's newly uploaded keys and could get stuck waiting for decryption keys.

The cursor map also avoids a related race: concurrent sliding sync requests for the same `conn_id` can advance stored connection state out of order. Room timelines already need replay protection for this; E2EE device-list cursors need the same treatment because they use a different stream.

### Sliding sync timeline cursor replay

- Add a room cursor helper that never starts a room timeline after the client-supplied `pos`.
- For non-initial room syncs, use `min(storedRoomPos, clientSincePos)`.

This avoids losing live timeline events when the same `conn_id` has overlapping or retried sliding sync requests. Previously, one request could advance stored room state, while another client request still resumed from an older `pos`; the server could then return the newer global `pos` with an empty room timeline. The client would persist the advanced `pos` and never receive the skipped event.

### Membership and invite sync wakeups

- Allow `notifyUsersOfEvent` to notify explicit extra users in addition to joined room members.
- Notify invitees, leaving users, kicked/banned users, and unbanned users for relevant membership changes.
- Notify after `/join/:roomIdOrAlias` so that both join paths wake sync consistently.
- Include invited users for key visibility only when the requester is joined in that room, so joined inviters can see invitee key changes without exposing key changes between unrelated invitees.

This prevents invite targets and users transitioning out of joined membership from missing sync wakeups or E2EE key visibility.

### To-device delivery wakeups

- Wake recipients' sync Durable Objects after `/sendToDevice` inserts to-device messages.
- Generate unique synthetic wakeup event IDs with `txnId`, recipient ID, and `crypto.randomUUID()` instead of relying on `Date.now()` alone.
- Use deterministic to-device message IDs per `(sender, txnId, recipient, device, eventType)` so retries remain idempotent.
- Store the transaction ID only after sync wakeups are accepted. If wakeup fails, a client retry attempts notification again without duplicating stored messages.
- On duplicate transactions, re-notify pending undelivered recipients before returning the cached response.

This matters for E2EE because room keys are commonly transported through to-device messages. Without waking long-polling sync, a recipient can wait until timeout before seeing key material, causing temporary or persistent "waiting for decryption key" behavior in clients.

### User directory exact lookup fallback

- Trim search terms and run exact Matrix ID/localpart lookup before FTS.
- Make FTS optional and fall back to SQL `LIKE` search if the `users_fts` table is unavailable or the query is unsuitable for FTS.
- Return explicit `null` profile fields so clients can distinguish found users from missing users.

This fixes client flows where direct Matrix ID lookup, short localpart search, or deployments without the optional FTS table failed to find existing local users.

### Push notification reliability

- Compute unread counts by joining the fully-read event ID back to its stream ordering instead of comparing an integer stream ordering to a string event ID.
- Ignore disabled pushers.
- Parse push gateway responses and treat rejected pushkeys as failures.
- Record notification queue `pushed` state based on actual gateway success.
- Add success/failure logging around gateway delivery.

This makes push accounting match actual delivery outcomes and prevents disabled or rejected pushers from looking successful.

## Validation

- `npm run typecheck`
- `git diff --check`
- Live interoperability testing against Element X clients confirmed:
  - E2EE device-list changes are reported after another user uploads keys.
  - `/keys/query`, `/keys/claim`, to-device key transport, and encrypted room timeline delivery complete end to end.
  - A previously reproducible sliding sync response that returned a newer `pos` with an empty timeline now returns the missing encrypted event.
  - User directory lookup finds local users by full Matrix ID and short localpart.
  - Push gateway success is reflected in pusher state.

## Notes

This PR deliberately excludes deployment-specific changes from the downstream test deployment, including Worker account configuration, resource IDs, local environment files, CI workflow removal, and unrelated VoIP/deployment adjustments.

## Follow-up update

This branch now also includes two additional sync hardening fixes that are part of the same delivery problem space:

- `/sync` and sliding sync pass the request start timestamp into the Sync Durable Object wait call. The Durable Object checks recent pending notifications before registering a waiter, so a notification that arrives between request evaluation and waiter registration does not get lost until timeout.
- To-device sync keeps the per-device cursor unchanged on an empty result instead of advancing it to the global to-device max stream position. This avoids skipping messages for this device when other devices have newer to-device rows, and avoids a race with messages inserted just after the empty query.

The downstream-only 10 second long-poll cap is intentionally not included here; the upstream PR keeps the existing 25 second cap.

## Review follow-up: reused sync positions

Addressed the device-key cursor review concern by only committing a device-key cursor when the returned sliding-sync event `pos` advances beyond the request `pos`. If a response contains only E2EE device-list changes and reuses the same event-stream token, a lost/retried response will replay those device-key changes instead of treating them as acknowledged.