### PR TITLE
Fix empty state-key routes and persist event relations

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -81,6 +81,14 @@ npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/005_idp_provider
 npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/006_query_optimization.sql
 npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/007_secure_server_keys.sql
 npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/008_federation_transactions.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/009_reports_extended.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/010_fix_reports_schema.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/011_identity_service.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/012_fts_search.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/013_remote_device_lists.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/014_appservice.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/015_identity_associations.sql
+npx wrangler d1 execute YOUR_DB_NAME --remote --file=migrations/016_event_relations_backfill.sql
 ```
 
 #### 3. Configure Custom Domain
@@ -331,6 +339,14 @@ npx wrangler d1 execute my-matrix-db --remote --file=migrations/005_idp_provider
 npx wrangler d1 execute my-matrix-db --remote --file=migrations/006_query_optimization.sql
 npx wrangler d1 execute my-matrix-db --remote --file=migrations/007_secure_server_keys.sql
 npx wrangler d1 execute my-matrix-db --remote --file=migrations/008_federation_transactions.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/009_reports_extended.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/010_fix_reports_schema.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/011_identity_service.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/012_fts_search.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/013_remote_device_lists.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/014_appservice.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/015_identity_associations.sql
+npx wrangler d1 execute my-matrix-db --remote --file=migrations/016_event_relations_backfill.sql
 ```
 
 Each migration should complete with "success": true.

--- a/migrations/016_event_relations_backfill.sql
+++ b/migrations/016_event_relations_backfill.sql
@@ -1,0 +1,27 @@
+-- Migration: Event relations persistence and backfill
+-- Keeps Matrix relations/threads out of JSON-only event content so relations endpoints
+-- continue to work after deploys and on databases that predate relation persistence.
+
+CREATE TABLE IF NOT EXISTS event_relations (
+    event_id TEXT NOT NULL,
+    relates_to_id TEXT NOT NULL,
+    relation_type TEXT NOT NULL,
+    aggregation_key TEXT,
+    PRIMARY KEY (event_id, relates_to_id, relation_type),
+    FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_relations_target ON event_relations(relates_to_id);
+CREATE INDEX IF NOT EXISTS idx_relations_type ON event_relations(relation_type);
+CREATE INDEX IF NOT EXISTS idx_relations_target_type ON event_relations(relates_to_id, relation_type);
+
+INSERT OR IGNORE INTO event_relations (event_id, relates_to_id, relation_type, aggregation_key)
+SELECT
+    event_id,
+    json_extract(content, '$."m.relates_to".event_id'),
+    json_extract(content, '$."m.relates_to".rel_type'),
+    json_extract(content, '$."m.relates_to".key')
+FROM events
+WHERE json_type(content, '$."m.relates_to"') = 'object'
+  AND json_type(content, '$."m.relates_to".event_id') = 'text'
+  AND json_type(content, '$."m.relates_to".rel_type') = 'text';

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -120,6 +120,7 @@ CREATE TABLE IF NOT EXISTS event_relations (
 );
 CREATE INDEX IF NOT EXISTS idx_relations_target ON event_relations(relates_to_id);
 CREATE INDEX IF NOT EXISTS idx_relations_type ON event_relations(relation_type);
+CREATE INDEX IF NOT EXISTS idx_relations_target_type ON event_relations(relates_to_id, relation_type);
 
 -- Push rules (per-user notification settings)
 CREATE TABLE IF NOT EXISTS push_rules (

--- a/src/api/relations.ts
+++ b/src/api/relations.ts
@@ -54,7 +54,8 @@ app.get('/_matrix/client/v1/rooms/:roomId/relations/:eventId', requireAuth(), as
   let query = `
     SELECT e.event_id, e.event_type, e.sender, e.origin_server_ts, e.content
     FROM events e
-    WHERE e.room_id = ? AND e.relates_to_event_id = ?
+    JOIN event_relations er ON er.event_id = e.event_id
+    WHERE e.room_id = ? AND er.relates_to_id = ?
   `;
   const params: any[] = [roomId, eventId];
 
@@ -124,7 +125,8 @@ app.get('/_matrix/client/v1/rooms/:roomId/relations/:eventId/:relType', requireA
   const results = await db.prepare(`
     SELECT e.event_id, e.event_type, e.sender, e.origin_server_ts, e.content
     FROM events e
-    WHERE e.room_id = ? AND e.relates_to_event_id = ? AND e.relation_type = ?
+    JOIN event_relations er ON er.event_id = e.event_id
+    WHERE e.room_id = ? AND er.relates_to_id = ? AND er.relation_type = ?
     ORDER BY e.origin_server_ts ${dir === 'b' ? 'DESC' : 'ASC'}
     LIMIT ?
   `).bind(roomId, eventId, relType, limit + 1).all<{
@@ -181,7 +183,8 @@ app.get('/_matrix/client/v1/rooms/:roomId/relations/:eventId/:relType/:eventType
   const results = await db.prepare(`
     SELECT e.event_id, e.event_type, e.sender, e.origin_server_ts, e.content
     FROM events e
-    WHERE e.room_id = ? AND e.relates_to_event_id = ? AND e.relation_type = ? AND e.event_type = ?
+    JOIN event_relations er ON er.event_id = e.event_id
+    WHERE e.room_id = ? AND er.relates_to_id = ? AND er.relation_type = ? AND e.event_type = ?
     ORDER BY e.origin_server_ts ${dir === 'b' ? 'DESC' : 'ASC'}
     LIMIT ?
   `).bind(roomId, eventId, relType, eventType, limit + 1).all<{
@@ -236,15 +239,22 @@ app.get('/_matrix/client/v1/rooms/:roomId/threads', requireAuth(), async (c) => 
     SELECT DISTINCT e.event_id, e.event_type, e.sender, e.origin_server_ts, e.content
     FROM events e
     WHERE e.room_id = ? AND e.event_id IN (
-      SELECT DISTINCT relates_to_event_id FROM events
-      WHERE room_id = ? AND relation_type = 'm.thread'
+      SELECT DISTINCT er.relates_to_id
+      FROM event_relations er
+      JOIN events child ON child.event_id = er.event_id
+      WHERE child.room_id = ? AND er.relation_type = 'm.thread'
     )
   `;
   const params: any[] = [roomId, roomId];
 
   if (include === 'participated') {
     query += ` AND (e.sender = ? OR EXISTS (
-      SELECT 1 FROM events r WHERE r.relates_to_event_id = e.event_id AND r.sender = ?
+      SELECT 1
+      FROM event_relations er2
+      JOIN events r ON r.event_id = er2.event_id
+      WHERE er2.relates_to_id = e.event_id
+        AND er2.relation_type = 'm.thread'
+        AND r.sender = ?
     ))`;
     params.push(userId, userId);
   }

--- a/src/api/rooms.ts
+++ b/src/api/rooms.ts
@@ -1,6 +1,6 @@
 // Matrix room endpoints
 
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import type { AppEnv, RoomCreateContent, RoomMemberContent, PDU } from '../types';
 import { Errors } from '../utils/errors';
 import { requireAuth } from '../middleware/auth';
@@ -747,8 +747,7 @@ app.get('/_matrix/client/v3/rooms/:roomId/state', requireAuth(), async (c) => {
   return c.json(clientEvents);
 });
 
-// GET /_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey? - Get specific state
-app.get('/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey?', requireAuth(), async (c) => {
+async function handleGetSpecificState(c: Context<AppEnv>) {
   const userId = c.get('userId');
   const roomId = c.req.param('roomId');
   const eventType = c.req.param('eventType');
@@ -766,10 +765,18 @@ app.get('/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey?', requireA
   }
 
   return c.json(event.content);
-});
+}
 
-// PUT /_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey? - Set state
-app.put('/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey?', requireAuth(), async (c) => {
+// GET /_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey - Get specific state
+app.get('/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey', requireAuth(), handleGetSpecificState);
+
+// GET /_matrix/client/v3/rooms/:roomId/state/:eventType/ - Get specific state with empty state_key
+app.get('/_matrix/client/v3/rooms/:roomId/state/:eventType/', requireAuth(), handleGetSpecificState);
+
+// GET /_matrix/client/v3/rooms/:roomId/state/:eventType - Get specific state with omitted empty state_key
+app.get('/_matrix/client/v3/rooms/:roomId/state/:eventType', requireAuth(), handleGetSpecificState);
+
+async function handlePutState(c: Context<AppEnv>) {
   const userId = c.get('userId');
   const roomId = c.req.param('roomId');
   const eventType = c.req.param('eventType');
@@ -840,7 +847,16 @@ app.put('/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey?', requireA
   await notifyUsersOfEvent(c.env, roomId, eventId, eventType);
 
   return c.json({ event_id: eventId });
-});
+}
+
+// PUT /_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey - Set state
+app.put('/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey', requireAuth(), handlePutState);
+
+// PUT /_matrix/client/v3/rooms/:roomId/state/:eventType/ - Set state with empty state_key
+app.put('/_matrix/client/v3/rooms/:roomId/state/:eventType/', requireAuth(), handlePutState);
+
+// PUT /_matrix/client/v3/rooms/:roomId/state/:eventType - Set state with omitted empty state_key
+app.put('/_matrix/client/v3/rooms/:roomId/state/:eventType', requireAuth(), handlePutState);
 
 // GET /_matrix/client/v3/rooms/:roomId/members - Get room members
 app.get('/_matrix/client/v3/rooms/:roomId/members', requireAuth(), async (c) => {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -289,6 +289,26 @@ export async function storeEvent(db: D1Database, event: PDU): Promise<number> {
     ).bind(event.room_id, event.type, event.state_key, event.event_id).run();
   }
 
+  const relatesTo = event.content['m.relates_to'];
+  if (relatesTo && typeof relatesTo === 'object' && !Array.isArray(relatesTo)) {
+    const relation = relatesTo as Record<string, unknown>;
+    const relatesToId = relation.event_id;
+    const relationType = relation.rel_type;
+    const aggregationKey = relation.key;
+
+    if (typeof relatesToId === 'string' && typeof relationType === 'string') {
+      await db.prepare(`
+        INSERT OR REPLACE INTO event_relations (event_id, relates_to_id, relation_type, aggregation_key)
+        VALUES (?, ?, ?, ?)
+      `).bind(
+        event.event_id,
+        relatesToId,
+        relationType,
+        typeof aggregationKey === 'string' ? aggregationKey : null
+      ).run();
+    }
+  }
+
   return streamOrdering;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes two generic Matrix client/server interoperability issues that are independent of any specific deployment:

- Matrix state events with an empty `state_key` can be addressed with a trailing slash, for example `PUT /_matrix/client/v3/rooms/:roomId/state/m.room.avatar/`. The current Hono route using `:stateKey?` does not match that trailing-slash form, so clients can receive a 404 while updating room metadata such as avatars.
- The relations and threads API queries columns (`events.relates_to_event_id`, `events.relation_type`) that are not present in the schema. The schema already models relations through `event_relations`, but new events were not populating that table and existing relation events were not backfilled.

I kept this separate from #17, which already covers sliding-sync/E2EE/push delivery fixes, to avoid duplicating that open PR or mixing unrelated review topics.

## What changed

### Empty `state_key` state routes

- Split the specific state handlers into reusable `handleGetSpecificState` and `handlePutState` functions.
- Register explicit GET and PUT routes for all three valid forms:
  - `.../state/:eventType/:stateKey`
  - `.../state/:eventType/`
  - `.../state/:eventType`
- Continue normalizing a missing state key to `''`, preserving the existing storage behavior.

This allows clients to update room-level state events whose state key is intentionally empty, including `m.room.avatar`, `m.room.name`, `m.room.topic`, and similar room metadata events.

### Relations and threads persistence

- Change `/relations` and `/threads` queries to join `event_relations` instead of reading non-existent relation columns from `events`.
- Persist `content[\"m.relates_to\"]` into `event_relations` when storing new events.
- Add an idempotent D1 migration, `016_event_relations_backfill.sql`, that:
  - creates `event_relations` if needed,
  - creates relation indexes,
  - backfills existing relation rows from JSON event content.
- Add `idx_relations_target_type` to `schema.sql` for fresh databases.
- Update `DEPLOYMENT.md` so the manual migration list includes the existing later migrations and the new `016` migration.

This fixes runtime 500s on thread/relation endpoints and makes reactions, replacements, and thread replies queryable after deploys and database migrations.

## Scope notes

- No deployment-specific Worker config, account IDs, database IDs, domains, local environment files, or downstream-only settings are included.
- No changes from the already-open sync/E2EE/push PR (#17) are duplicated here.
- The migration is idempotent: it uses `CREATE ... IF NOT EXISTS` and `INSERT OR IGNORE`, so it can be safely applied to existing D1 databases.

## Validation

- `npm run typecheck`
- `npx vitest run --passWithNoTests` (the repository currently has no test files)
- `git diff --check`
- Downstream smoke validation:
  - `PUT` and `GET` for `m.room.avatar` with a trailing slash return 200.
  - `/threads` returns 200 after relation backfill instead of D1 column errors.