### PR TITLE
Issue signed OIDC id_token (fixes Element Web/Desktop login)

### DIFF
--- a/src/api/oauth.ts
+++ b/src/api/oauth.ts
@@ -8,6 +8,8 @@ import { requireAuth } from '../middleware/auth';
 import { hashToken, verifyPassword } from '../utils/crypto';
 import { generateAccessToken, generateDeviceId, generateOpaqueId, formatUserId } from '../utils/ids';
 import { createDevice, createAccessToken, getUserById } from '../services/database';
+import { signIdToken } from '../services/oidc-id-token';
+import { getOrCreateOidcSigningKey } from '../services/oidc-keys';
 
 const app = new Hono<AppEnv>();
 
@@ -461,12 +463,32 @@ app.post('/oauth/token', async (c) => {
       expirationTtl: 30 * 24 * 60 * 60, // 30 days
     });
 
+    // OIDC: issue a signed id_token when the openid scope was granted. Element
+    // Web/Desktop (oidc-client-ts) require and verify this against the JWKS;
+    // without it they fail auth after a successful token exchange. Element X
+    // (pure OAuth2) ignores it.
+    let idToken: string | undefined;
+    if (scopes.includes('openid')) {
+      const signingKey = await getOrCreateOidcSigningKey(c.env.CACHE);
+      idToken = await signIdToken({
+        issuer: `https://${c.env.SERVER_NAME}`,
+        subject: authCode.user_id,
+        audience: effectiveClientId,
+        nonce: authCode.nonce,
+        nowSec: Math.floor(Date.now() / 1000),
+        expiresInSec: 86400,
+        privateKeyJwk: signingKey.privateKeyJwk,
+        kid: signingKey.kid,
+      });
+    }
+
     return c.json({
       access_token: accessToken,
       token_type: 'Bearer',
       expires_in: 86400, // 24 hours
       refresh_token: newRefreshToken,
       scope: authCode.scope,
+      ...(idToken ? { id_token: idToken } : {}),
       // Matrix-specific fields
       user_id: authCode.user_id,
       device_id: deviceId,
@@ -518,12 +540,28 @@ app.post('/oauth/token', async (c) => {
       expirationTtl: 30 * 24 * 60 * 60,
     });
 
+    // Re-issue an id_token on refresh too (no nonce on refresh, per OIDC).
+    let refreshIdToken: string | undefined;
+    if ((tokenData.scope?.split(' ') || []).includes('openid')) {
+      const signingKey = await getOrCreateOidcSigningKey(c.env.CACHE);
+      refreshIdToken = await signIdToken({
+        issuer: `https://${c.env.SERVER_NAME}`,
+        subject: tokenData.user_id,
+        audience: effectiveClientId,
+        nowSec: Math.floor(Date.now() / 1000),
+        expiresInSec: 86400,
+        privateKeyJwk: signingKey.privateKeyJwk,
+        kid: signingKey.kid,
+      });
+    }
+
     return c.json({
       access_token: newAccessToken,
       token_type: 'Bearer',
       expires_in: 86400,
       refresh_token: newRefreshToken,
       scope: tokenData.scope,
+      ...(refreshIdToken ? { id_token: refreshIdToken } : {}),
     });
 
   } else {

--- a/src/api/oidc-auth.ts
+++ b/src/api/oidc-auth.ts
@@ -457,10 +457,13 @@ app.get('/_matrix/client/v1/auth_metadata', async (c) => {
     token_endpoint: `${baseUrl}/oauth/token`,
     revocation_endpoint: `${baseUrl}/oauth/revoke`,
     registration_endpoint: `${baseUrl}/oauth/register`,
+    // JWKS for verifying id_tokens — required by oidc-client-ts (Element Web/Desktop)
+    jwks_uri: `${baseUrl}/.well-known/jwks.json`,
     // Required capabilities
     response_types_supported: ['code'],
     grant_types_supported: ['authorization_code', 'refresh_token'],
     code_challenge_methods_supported: ['S256', 'plain'],
+    id_token_signing_alg_values_supported: ['RS256'],
     // Additional optional fields that Element Web may check
     token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
     scopes_supported: [

--- a/src/api/versions.ts
+++ b/src/api/versions.ts
@@ -2,6 +2,7 @@
 
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
+import { getOrCreateOidcSigningKey } from '../services/oidc-keys';
 
 const app = new Hono<AppEnv>();
 
@@ -72,7 +73,7 @@ app.get('/.well-known/openid-configuration', (c) => {
     token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
     code_challenge_methods_supported: ['S256', 'plain'],
     subject_types_supported: ['public'],
-    id_token_signing_alg_values_supported: ['RS256', 'ES256'],
+    id_token_signing_alg_values_supported: ['RS256'],
     claims_supported: ['sub', 'iss', 'aud', 'exp', 'iat', 'name', 'email'],
     // Matrix-specific extension
     'org.matrix.matrix-authentication-service': {
@@ -85,12 +86,12 @@ app.get('/.well-known/openid-configuration', (c) => {
 });
 
 // GET /.well-known/jwks.json - JSON Web Key Set for token verification
-app.get('/.well-known/jwks.json', (c) => {
-  // Return an empty JWKS - clients can't verify our tokens without keys
-  // In a real implementation, you'd generate and store RSA keys
-  // For now, returning a placeholder that indicates we use opaque tokens
+app.get('/.well-known/jwks.json', async (c) => {
+  // Publish the OIDC id_token signing key so clients (e.g. Element Web/Desktop)
+  // can verify id_tokens issued by /oauth/token.
+  const signingKey = await getOrCreateOidcSigningKey(c.env.CACHE);
   return c.json({
-    keys: [],
+    keys: [signingKey.publicKeyJwk],
   });
 });
 

--- a/src/services/oidc-id-token.test.ts
+++ b/src/services/oidc-id-token.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { signIdToken } from './oidc-id-token';
+
+function b64urlToString(segment: string): string {
+  return atob(segment.replace(/-/g, '+').replace(/_/g, '/'));
+}
+
+function b64urlToBytes(segment: string): Uint8Array {
+  const binary = atob(segment.replace(/-/g, '+').replace(/_/g, '/'));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function generateRsaKeyPair() {
+  const kp = (await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+  return {
+    privateKeyJwk: (await crypto.subtle.exportKey('jwk', kp.privateKey)) as JsonWebKey,
+    publicKeyJwk: (await crypto.subtle.exportKey('jwk', kp.publicKey)) as JsonWebKey,
+  };
+}
+
+describe('signIdToken', () => {
+  it('produces an RS256 JWT with the required OIDC claims and a verifiable signature', async () => {
+    const { privateKeyJwk, publicKeyJwk } = await generateRsaKeyPair();
+    const nowSec = 1_700_000_000;
+
+    const jwt = await signIdToken({
+      issuer: 'https://m.gsudo.net',
+      subject: '@admin:m.gsudo.net',
+      audience: 'client_abc',
+      nonce: 'n-123',
+      nowSec,
+      expiresInSec: 3600,
+      privateKeyJwk,
+      kid: 'kid-1',
+    });
+
+    const [headerB64, payloadB64, signatureB64] = jwt.split('.');
+    expect(signatureB64, 'JWT must have three segments').toBeTruthy();
+
+    const header = JSON.parse(b64urlToString(headerB64));
+    const payload = JSON.parse(b64urlToString(payloadB64));
+
+    // OIDC-required header
+    expect(header).toMatchObject({ alg: 'RS256', typ: 'JWT', kid: 'kid-1' });
+
+    // OIDC-required claims (the bits Element Web/Desktop validate)
+    expect(payload).toMatchObject({
+      iss: 'https://m.gsudo.net',
+      sub: '@admin:m.gsudo.net',
+      aud: 'client_abc',
+      nonce: 'n-123',
+      iat: nowSec,
+      exp: nowSec + 3600,
+    });
+
+    // Signature must verify against the public key
+    const publicKey = await crypto.subtle.importKey(
+      'jwk',
+      publicKeyJwk,
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      false,
+      ['verify'],
+    );
+    const verified = await crypto.subtle.verify(
+      'RSASSA-PKCS1-v1_5',
+      publicKey,
+      b64urlToBytes(signatureB64),
+      new TextEncoder().encode(`${headerB64}.${payloadB64}`),
+    );
+    expect(verified, 'id_token signature must verify against the JWKS public key').toBe(true);
+  });
+
+  it('omits the nonce claim when no nonce was provided', async () => {
+    const { privateKeyJwk } = await generateRsaKeyPair();
+    const jwt = await signIdToken({
+      issuer: 'https://m.gsudo.net',
+      subject: '@admin:m.gsudo.net',
+      audience: 'client_abc',
+      nowSec: 1_700_000_000,
+      expiresInSec: 3600,
+      privateKeyJwk,
+      kid: 'kid-1',
+    });
+    const payload = JSON.parse(b64urlToString(jwt.split('.')[1]));
+    expect(payload).not.toHaveProperty('nonce');
+  });
+});

--- a/src/services/oidc-id-token.ts
+++ b/src/services/oidc-id-token.ts
@@ -1,0 +1,62 @@
+// OIDC id_token issuance for the OAuth provider.
+//
+// Element X (Rust SDK / MSC3861 pure OAuth2) is happy with just an access token,
+// but Element Web/Desktop (oidc-client-ts) require a signed `id_token` whenever the
+// `openid` scope is requested, and verify it against the keys at `jwks_uri`. Without
+// it they fail authentication after a successful token exchange. This module signs
+// the id_token; see oidc-keys.ts for the RS256 signing key + JWKS.
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlEncodeString(value: string): string {
+  return base64UrlEncode(new TextEncoder().encode(value));
+}
+
+export interface IdTokenParams {
+  issuer: string;
+  subject: string;
+  audience: string;
+  nowSec: number;
+  expiresInSec: number;
+  privateKeyJwk: JsonWebKey;
+  kid: string;
+  nonce?: string;
+  atHash?: string;
+}
+
+/** Build and RS256-sign an OIDC id_token. Returns the compact JWT string. */
+export async function signIdToken(params: IdTokenParams): Promise<string> {
+  const header = { alg: 'RS256', typ: 'JWT', kid: params.kid };
+
+  const payload: Record<string, unknown> = {
+    iss: params.issuer,
+    sub: params.subject,
+    aud: params.audience,
+    iat: params.nowSec,
+    exp: params.nowSec + params.expiresInSec,
+  };
+  if (params.nonce) payload.nonce = params.nonce;
+  if (params.atHash) payload.at_hash = params.atHash;
+
+  const signingInput =
+    `${base64UrlEncodeString(JSON.stringify(header))}.${base64UrlEncodeString(JSON.stringify(payload))}`;
+
+  const key = await crypto.subtle.importKey(
+    'jwk',
+    params.privateKeyJwk,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+
+  return `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`;
+}

--- a/src/services/oidc-keys.test.ts
+++ b/src/services/oidc-keys.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { getOrCreateOidcSigningKey } from './oidc-keys';
+import { signIdToken } from './oidc-id-token';
+
+function b64urlToBytes(segment: string): Uint8Array {
+  const binary = atob(segment.replace(/-/g, '+').replace(/_/g, '/'));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function makeKvStub() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: async (k: string) => (store.has(k) ? store.get(k)! : null),
+    put: async (k: string, v: string) => void store.set(k, v),
+  };
+}
+
+describe('getOrCreateOidcSigningKey', () => {
+  it('generates a JWKS-ready RS256 public key on first use', async () => {
+    const kv = makeKvStub();
+    const key = await getOrCreateOidcSigningKey(kv);
+
+    expect(key.kid).toBeTruthy();
+    expect(key.publicKeyJwk).toMatchObject({ kty: 'RSA', use: 'sig', alg: 'RS256', kid: key.kid });
+    expect(key.publicKeyJwk.n).toBeTruthy();
+    expect(key.publicKeyJwk.e).toBeTruthy();
+    // private key never carries private material into the JWKS public copy
+    expect(key.publicKeyJwk).not.toHaveProperty('d');
+    // it was persisted
+    expect(kv.store.has('oidc_signing_key')).toBe(true);
+  });
+
+  it('returns the same persisted key on subsequent calls (idempotent)', async () => {
+    const kv = makeKvStub();
+    const first = await getOrCreateOidcSigningKey(kv);
+    const second = await getOrCreateOidcSigningKey(kv);
+
+    expect(second.kid).toBe(first.kid);
+    expect(second.publicKeyJwk.n).toBe(first.publicKeyJwk.n);
+  });
+
+  it('produces a key whose id_token signature verifies against its own public JWK', async () => {
+    const kv = makeKvStub();
+    const key = await getOrCreateOidcSigningKey(kv);
+
+    const jwt = await signIdToken({
+      issuer: 'https://m.gsudo.net',
+      subject: '@admin:m.gsudo.net',
+      audience: 'client_abc',
+      nowSec: 1_700_000_000,
+      expiresInSec: 3600,
+      privateKeyJwk: key.privateKeyJwk,
+      kid: key.kid,
+    });
+
+    const [h, p, s] = jwt.split('.');
+    const pub = await crypto.subtle.importKey(
+      'jwk',
+      // strip the JWKS-only metadata before importing
+      { kty: key.publicKeyJwk.kty, n: key.publicKeyJwk.n, e: key.publicKeyJwk.e },
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      false,
+      ['verify'],
+    );
+    const ok = await crypto.subtle.verify(
+      'RSASSA-PKCS1-v1_5',
+      pub,
+      b64urlToBytes(s),
+      new TextEncoder().encode(`${h}.${p}`),
+    );
+    expect(ok).toBe(true);
+  });
+});

--- a/src/services/oidc-keys.ts
+++ b/src/services/oidc-keys.ts
@@ -1,0 +1,73 @@
+// RS256 signing key for the OAuth provider's OIDC id_tokens.
+//
+// Generated once on first use and persisted in KV (mirrors how the Matrix server
+// signing key is auto-provisioned). The public half is published at the JWKS
+// endpoint so clients like Element Web/Desktop can verify id_tokens. See
+// oidc-id-token.ts for the signing itself.
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Minimal KV surface this module needs (satisfied by Cloudflare KVNamespace). */
+export interface KVLike {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string): Promise<void>;
+}
+
+export interface PublicJwk {
+  kty: string;
+  n: string;
+  e: string;
+  use: 'sig';
+  alg: 'RS256';
+  kid: string;
+}
+
+export interface OidcSigningKey {
+  privateKeyJwk: JsonWebKey;
+  publicKeyJwk: PublicJwk;
+  kid: string;
+}
+
+const STORAGE_KEY = 'oidc_signing_key';
+
+async function computeKid(publicKeyJwk: JsonWebKey): Promise<string> {
+  const material = new TextEncoder().encode(`${publicKeyJwk.n}.${publicKeyJwk.e}`);
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', material));
+  return base64UrlEncode(digest).slice(0, 16);
+}
+
+/**
+ * Load the OIDC signing key from KV, generating and persisting it on first use.
+ * Idempotent: subsequent calls return the same key.
+ */
+export async function getOrCreateOidcSigningKey(kv: KVLike): Promise<OidcSigningKey> {
+  const existing = await kv.get(STORAGE_KEY);
+  if (existing) return JSON.parse(existing) as OidcSigningKey;
+
+  const pair = (await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+
+  const privateKeyJwk = (await crypto.subtle.exportKey('jwk', pair.privateKey)) as JsonWebKey;
+  const rawPublicJwk = (await crypto.subtle.exportKey('jwk', pair.publicKey)) as JsonWebKey;
+  const kid = await computeKid(rawPublicJwk);
+
+  const publicKeyJwk: PublicJwk = {
+    kty: rawPublicJwk.kty as string,
+    n: rawPublicJwk.n as string,
+    e: rawPublicJwk.e as string,
+    use: 'sig',
+    alg: 'RS256',
+    kid,
+  };
+
+  const key: OidcSigningKey = { privateKeyJwk, publicKeyJwk, kid };
+  await kv.put(STORAGE_KEY, JSON.stringify(key));
+  return key;
+}


### PR DESCRIPTION
## Problem

OIDC-native login fails in clients built on `oidc-client-ts` (Element Web, Element Desktop) with *"Something went wrong during authentication"* — and it fails **after** an otherwise-successful token exchange. Element X (Rust SDK / MSC3861 pure OAuth2) is unaffected, which makes it look client-specific.

## Root cause

The OAuth provider advertises OIDC and accepts the `openid` scope, but `/oauth/token` never returns an `id_token`, and `/.well-known/jwks.json` returns an empty key set. Per OIDC, an `openid` authorization-code flow must return a verifiable `id_token`; `oidc-client-ts` requires it and verifies its signature against `jwks_uri`, so it rejects the response. Element X doesn't require an `id_token`, so it works.

Confirmed via server logs: the flow runs `GET /oauth/authorize 200 → POST /oauth/authorize 302 → POST /oauth/token 200`, after which the client makes no further requests and shows the error.

## Fix

- `services/oidc-id-token.ts` — RS256-sign an `id_token` (`iss`, `sub`, `aud`, `iat`, `exp`, `nonce`).
- `services/oidc-keys.ts` — generate the RS256 signing key on first use and persist it in KV (mirrors the existing server-signing-key pattern); expose the public JWK for JWKS.
- `/oauth/token` — return `id_token` for the `authorization_code` and `refresh_token` grants when `openid` is requested.
- `/.well-known/jwks.json` — publish the real signing key (was `{ "keys": [] }`).
- `/_matrix/client/v1/auth_metadata` — advertise `jwks_uri` and `id_token_signing_alg_values_supported`.

`id_token` issuance is purely additive — pure-OAuth2 clients (Element X) are unaffected.

## Testing

- Unit tests (vitest) for `signIdToken` (claims + signature verification) and `getOrCreateOidcSigningKey` (generate/persist/reload + JWKS round-trip); `tsc --noEmit` clean.
- Deployed and verified end-to-end: Element Desktop (macOS) now logs in; the live JWKS serves the key and `auth_metadata` advertises `jwks_uri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
